### PR TITLE
policy-attachment-fixes

### DIFF
--- a/banyan/resource_policy_attachment.go
+++ b/banyan/resource_policy_attachment.go
@@ -26,17 +26,20 @@ func resourcePolicyAttachment() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of your service",
+				ForceNew:    true,
 			},
 			"attached_to_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "description of your service",
+				ForceNew:    true,
 			},
 			"attached_to_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "what the policy is attached to",
 				ValidateFunc: validateAttachedToType(),
+				ForceNew:     true,
 			},
 			"is_enforcing": {
 				Type:        schema.TypeBool,

--- a/client/policyattachment/model.go
+++ b/client/policyattachment/model.go
@@ -23,3 +23,17 @@ type DetachBody struct {
 	AttachedToID   string `json:"attached_to_id"`
 	AttachedToType string `json:"attached_to_type"`
 }
+
+type RegisteredServiceAttachCreateBody struct {
+	PolicyID  string `json:"PolicyID"`
+	ServiceID string `json:"ServiceID"`
+	Enabled   string `json:"Enabled"`
+}
+
+type RegisteredServiceAttachCreateResponseBody struct {
+	PolicyID   string `json:"PolicyID"`
+	ServiceID  string `json:"ServiceID"`
+	Enabled    string `json:"Enabled"`
+	AttachedBy string `json:"AttachedBy"`
+	AttachedAt int `json:"AttachedAt"`
+}

--- a/examples/.terraform.lock.hcl
+++ b/examples/.terraform.lock.hcl
@@ -5,6 +5,6 @@ provider "github.com/banyansecurity/banyan" {
   version     = "0.1.0"
   constraints = "0.1.0"
   hashes = [
-    "h1:sRjjfGAqbB65F0os5YV01DxGDU23IFplddDf/dmC9Hk=",
+    "h1:KKyBuu0uE/MZ1spth8FGCqhJGGeYAiD+OU3dcBhuV9I=",
   ]
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -57,173 +57,173 @@ provider "banyan" {
 //    group_id = data.okta_everyone_group.everyone.id
 //}
 
-//resource "banyan_service" "test-service" {
-//  cluster = "dev05-banyan"
-//  name = "realtftest"
-//  description = "description2"
-//  metadatatags {
-//    domain = "test2.com"
-//    port = 1111
-//    protocol = "https"
-//    service_app_type = "WEB"
-//    user_facing = false
-//    template= "WEB_USER"
-//    app_listen_port = 9191
-//    include_domains = ["test.com"]
-//  }
-//  spec {
-//    client_cidrs {
-//      clusters = ["cliuster1&&&"]
-//      address {
-//        cidr = "127.127.127.1/32"
-//        ports = "888"
-//      }
-//      address {
-//        cidr = "255.220.225.1/32"
-//        ports = "111"
-//      }
-//      host_tag_selectors {
-//        host_tag_selector ={
-//            "map" = "hi"
-//          }
-//        }
-//      host_tag_selectors {
-//        host_tag_selector ={
-//          "map" = "hi"
-//        }
-//     }
-//    }
-//    attributes {
-//      frontend_address {
-//        cidr = "127.44.111.14/32"
-//        port = "1111"
-//      }
-//      frontend_address {
-//        cidr = "127.99.114.14/32"
-//        port = 0
-//      }
-//      host_tag_selector {
-//        site_name = "sitename"
-//      }
-//      host_tag_selector {
-//        site_name = "sites"
-//      }
-//      tls_sni = ["sni_new2", "tls_sni616"]
-//    }
-//    backend {
-//      target {
-//        client_certificate = true
-//        name = "targetbacknd"
-//        port = 1515
-//        tls = true
-//        tls_insecure = true
-//      }
-//      dns_overrides = {
-//        "internal.mysvc.com" = "10.23.0.1"
-//        "exposed.service.com" : "internal.myservice.com"
-//      }
-//      backend_allowlist = ["allowme.com", "newurl.org"]
-//      http_connect = true
-//      connector_name = "hahah-connector-name"
-//      backend_allow_pattern {
-//        hostnames = ["backendallowhostName1", "hostname.com"]
-//        cidrs = ["99.99.99.99/9"]
-//        ports {
-//          port_list = [111,222]
-//          port_range {
-//            min = 1
-//            max = 5
-//          }
-//        }
-//      }
-//      backend_allow_pattern {
-//        hostnames = ["differentone.com", "foo.bar.baz"]
-//        cidrs = ["55.55.55.55/5"]
-//        ports {
-//          port_list = [88,99]
-//          port_range {
-//            min = 8
-//            max = 9
-//          }
-//        }
-//      }
-//    }
-//    cert_settings {
-//      letsencrypt = false
-//      dns_names = ["hello_dns_name", "dns_name2"]
-//      custom_tls_cert {
-//        enabled = false
-//        cert_file = "asdf"
-//        key_file = "asdf"
-//      }
-//    }
-//    http_settings {
-//      enabled = true
-//
-//      http_health_check {
-//        enabled = true
-//        addresses = ["88.99.101.2"]
-//        method = "GET"
-//        path = "/path"
-//        user_agent = "chrome"
-//        from_address = ["11.11.11.99"]
-//        https = true
-//      }
-//      http_redirect {
-//        enabled = true
-//        addresses = ["127.98.2.1"]
-//        from_address = ["43.12.31.1"]
-//        url = "hello.com"
-//        status_code = 209
-//      }
-//      oidc_settings {
-//        enabled = true
-//        service_domain_name = "service.domain.name"
-//        post_auth_redirect_path = "/new/path"
-//        api_path = "/api/path"
-//        suppress_device_trust_verification = true
-//        trust_callbacks = {
-//          "h" = "y"
-//          "b" = "j"
-//        }
-//      }
-//      headers = {
-//        "header1" = "headers"
-//      }
-//      exempted_paths {
-//        enabled = true
-//        paths = ["/path1", "/path2"]
-//        pattern {
-//          source_cidrs = ["222.222.222.222/8"]
-//          methods = ["GET"]
-//          paths = ["/path9000"]
-//          mandatory_headers = ["mandatory_header"]
-//          hosts {
-//            origin_header = [
-//              "https://originheader.org:80"]
-//            target = [
-//              "http://target.io:70"]
-//          }
-//        }
-//        pattern {
-//          source_cidrs = ["111.111.111.111/8"]
-//          methods = ["POST"]
-//          paths = ["/newPath"]
-//          mandatory_headers = ["other_header"]
-//          hosts {
-//            origin_header = [
-//              "http://other_originheader.com:90"]
-//            target = [
-//              "http://other_target.net:8080"]
-//          }
-//        }
-//      }
-//    }
-//  }
-//}
+resource "banyan_service" "test-service" {
+  cluster = "dev05-banyan"
+  name = "realtftest-new"
+  description = "description2"
+  metadatatags {
+    domain = "test2v.com"
+    port = 1111
+    protocol = "https"
+    service_app_type = "WEB"
+    user_facing = false
+    template= "WEB_USER"
+    app_listen_port = 9191
+    include_domains = ["test2v.com"]
+  }
+  spec {
+    client_cidrs {
+      clusters = ["cliuster1&&&"]
+      address {
+        cidr = "127.127.127.1/32"
+        ports = "888"
+      }
+      address {
+        cidr = "255.220.225.1/32"
+        ports = "111"
+      }
+      host_tag_selectors {
+        host_tag_selector ={
+            "map" = "hi"
+          }
+      }
+      host_tag_selectors {
+        host_tag_selector ={
+          "map" = "hi"
+        }
+      }
+    }
+    attributes {
+      frontend_address {
+        cidr = "127.44.111.13/32"
+        port = "1111"
+      }
+      frontend_address {
+        cidr = "127.99.114.15/32"
+        port = 0
+      }
+      host_tag_selector {
+        site_name = "sitename"
+      }
+      host_tag_selector {
+        site_name = "sites"
+      }
+      tls_sni = ["sni_new22", "tls_sni6162"]
+    }
+    backend {
+      target {
+        client_certificate = true
+        name = "targetbacknd"
+        port = 1515
+        tls = true
+        tls_insecure = true
+      }
+      dns_overrides = {
+        "internal.mysvc.com" = "10.23.0.1"
+        "exposed.service.com" : "internal.myservice.com"
+      }
+      backend_allowlist = ["allowme.com", "newurl.org"]
+      http_connect = true
+      connector_name = "hahah-connector-name"
+      backend_allow_pattern {
+        hostnames = ["backendallowhostName1", "hostname.com"]
+        cidrs = ["99.99.99.99/9"]
+        ports {
+          port_list = [111,222]
+          port_range {
+            min = 1
+            max = 5
+          }
+        }
+      }
+      backend_allow_pattern {
+        hostnames = ["differentone.com", "foo.bar.baz"]
+        cidrs = ["55.55.55.55/5"]
+        ports {
+          port_list = [88,99]
+          port_range {
+            min = 8
+            max = 9
+          }
+        }
+      }
+    }
+    cert_settings {
+      letsencrypt = false
+      dns_names = ["hello_dns_name", "dns_name2"]
+      custom_tls_cert {
+        enabled = false
+        cert_file = "asdf"
+        key_file = "asdf"
+      }
+    }
+    http_settings {
+      enabled = true
+
+      http_health_check {
+        enabled = true
+        addresses = ["88.99.101.2"]
+        method = "GET"
+        path = "/path"
+        user_agent = "chrome"
+        from_address = ["11.11.11.99"]
+        https = true
+      }
+      http_redirect {
+        enabled = true
+        addresses = ["127.98.2.1"]
+        from_address = ["43.12.31.1"]
+        url = "hello.com"
+        status_code = 209
+      }
+      oidc_settings {
+        enabled = true
+        service_domain_name = "service2.domain.name"
+        post_auth_redirect_path = "/new/path"
+        api_path = "/api/path"
+        suppress_device_trust_verification = true
+        trust_callbacks = {
+          "h" = "y"
+          "b" = "j"
+        }
+      }
+      headers = {
+        "header1" = "headers"
+      }
+      exempted_paths {
+        enabled = true
+        paths = ["/path1", "/path2"]
+        pattern {
+          source_cidrs = ["222.222.222.222/8"]
+          methods = ["GET"]
+          paths = ["/path9000"]
+          mandatory_headers = ["mandatory_header"]
+          hosts {
+            origin_header = [
+              "https://originheader.org:80"]
+            target = [
+              "http://target.io:70"]
+          }
+        }
+        pattern {
+          source_cidrs = ["111.111.111.111/8"]
+          methods = ["POST"]
+          paths = ["/newPath"]
+          mandatory_headers = ["other_header"]
+          hosts {
+            origin_header = [
+              "http://other_originheader.com:90"]
+            target = [
+              "http://other_target.net:8080"]
+          }
+        }
+      }
+    }
+  }
+}
 
 resource "banyan_policy" "test-policy" {
-  name = "realtfpolicytest"
+  name = "realtfpolicytest-new"
   description = "realdescription"
   metadatatags {
     template = "USER"
@@ -283,10 +283,10 @@ resource "banyan_role" "test-role" {
     mdm_present = true
   }
 }
-//
-//resource "banyan_policy_attachment" "test-attachment" {
-//  policy_id = banyan_policy.test-policy.id
-//  attached_to_type = "service"
-//  attached_to_id = banyan_service.test-service.id
-//  is_enforcing = true
-//}
+
+resource "banyan_policy_attachment" "test-attachment" {
+  policy_id = banyan_policy.test-policy.id
+  attached_to_type = "service"
+  attached_to_id = banyan_service.test-service.id
+  is_enforcing = true
+}


### PR DESCRIPTION
use a separate endpoint for service and policy attachment.
Force new changes for policy attachment because otherwise it would just actually create a new one