### PR TITLE
Handle not found

### DIFF
--- a/banyan/resource_policy.go
+++ b/banyan/resource_policy.go
@@ -476,8 +476,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface
 		return
 	}
 	if !ok {
-		diagnostics = diag.Errorf("couldn't find expected resource")
-		return
+		return handleNotFoundError(d, fmt.Sprintf("service %q", d.Id()))
 	}
 	log.Printf("[POLICY|RES|READ]: go policy: %#v", policy)
 	d.Set("name", policy.Name)

--- a/banyan/resource_policy_attachment.go
+++ b/banyan/resource_policy_attachment.go
@@ -140,8 +140,7 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 		return
 	}
 	if !ok {
-		diagnostics = diag.Errorf("couldn't find expected resource")
-		return
+		return handleNotFoundError(d, fmt.Sprintf("policy attachment %q", d.Id()))
 	}
 	log.Printf("[POLICYATTACHMENT|RES|READ] got policyAttachment: %#v", attachment)
 	d.Set("policy_id", attachment.PolicyID)

--- a/banyan/resource_role.go
+++ b/banyan/resource_role.go
@@ -279,8 +279,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		return
 	}
 	if !ok {
-		diagnostics = diag.Errorf("couldn't find expected resource")
-		return
+		return handleNotFoundError(d, fmt.Sprintf("role %q", d.Id()))
 	}
 	log.Printf("[ROLE|RES|READ] got role: %#v", role)
 	d.Set("name", role.Name)

--- a/banyan/resource_service.go
+++ b/banyan/resource_service.go
@@ -1527,8 +1527,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return
 	}
 	if !ok {
-		diagnostics = diag.Errorf("couldn't find expected resource")
-		return
+		return handleNotFoundError(d, fmt.Sprintf("service %q", d.Id()))
 	}
 	log.Printf("#### readService: %#v", service)
 	err = d.Set("name", service.ServiceName)

--- a/banyan/schema_helpers.go
+++ b/banyan/schema_helpers.go
@@ -3,6 +3,7 @@ package banyan
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -65,4 +66,11 @@ func convertSliceInterfaceToSliceMap(original []interface{}) (sliceOfStringMap [
 		sliceOfStringMap = append(sliceOfStringMap, stringMap)
 	}
 	return
+}
+
+func handleNotFoundError(d *schema.ResourceData, resource string) (diagnostics diag.Diagnostics) {
+	log.Printf("[WARN] Removing %s because it's gone", resource)
+	// The resource doesn't exist anymore
+	d.SetId("")
+	return nil
 }


### PR DESCRIPTION
Borrowed this trick from the GCP Terraform provider. Setting the 'id' of a resource to an empty string deletes it from the terraform state