### PR TITLE
update go version to 1.20.5 in releaser

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20.5
+      -
+        name: Run Go Mod Tidy
+        run: go mod tidy
       -
         name: Test
         run: go test ./banyan/... -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20.5
       -
         name: Test
         run: go test ./banyan/... -v

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,7 +18,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.20.5
+      -
+        name: Run Go Mod Tidy
+        run: go mod tidy
       -
         name: Test
         run: go test ./banyan/... -v


### PR DESCRIPTION
* Update releaser go version to 1.20.5
* Adding a step to include go mod tidy in tests to avoid mod tidy compatibility if go version is upgraded.