### PR TITLE
add support of http2 in registered web service

### DIFF
--- a/banyan/resource_service_web.go
+++ b/banyan/resource_service_web.go
@@ -312,6 +312,12 @@ func WebSchema() (s map[string]*schema.Schema) {
 			Default:     true,
 			Description: "enable / disable web service",
 		},
+		"enable_http2": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "enable / disable http2 for web service",
+		},
 	}
 	return
 }
@@ -407,6 +413,11 @@ func resourceServiceWebRead(ctx context.Context, d *schema.ResourceData, m inter
 	}
 
 	err = d.Set("enable", isWebServiceEnable)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set("enable_http2", svc.CreateServiceSpec.Spec.HTTPSettings.EnableHTTP2)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -639,6 +650,7 @@ func expandWebHTTPSettings(d *schema.ResourceData) (httpSettings service.HTTPSet
 		Headers:           expandCustomHttpHeaders(d),
 		HTTPHealthCheck:   expandWebHTTPHealthCheck(),
 		TokenLoc:          expandWebTokenLoc(d),
+		EnableHTTP2:       expandEnableHTTP2(d),
 	}
 	return
 }
@@ -786,4 +798,12 @@ func flattenCustomTrustCookie(customTrustCookie *service.CustomTrustCookie) (fla
 		flattened = append(flattened, tl)
 	}
 	return
+}
+
+func expandEnableHTTP2(d *schema.ResourceData) bool {
+	autorun, exists := d.GetOk("enable_http2")
+	if exists {
+		return autorun.(bool)
+	}
+	return false
 }

--- a/client/service/model.go
+++ b/client/service/model.go
@@ -120,8 +120,9 @@ type HTTPSettings struct {
 	// the key of the map is the header name, and the value is the header value you want.
 	// The header value may be constructed using Go template syntax, such as {{.Email}}
 	// referencing values in Banyan's JWT TrustToken.
-	Headers  map[string]string `json:"headers" toml:"headers"`
-	TokenLoc *TokenLocation    `json:"token_loc,omitempty" toml:"token_loc"`
+	Headers     map[string]string `json:"headers" toml:"headers"`
+	TokenLoc    *TokenLocation    `json:"token_loc,omitempty" toml:"token_loc"`
+	EnableHTTP2 bool              `json:"enable_http2,omitempty" toml:"enable_http2"`
 }
 
 type CustomTrustCookie struct {


### PR DESCRIPTION
Testing screenshots :  

<img width="1256" height="957" alt="Screenshot from 2025-07-28 16-47-10" src="https://github.com/user-attachments/assets/bc2cdbeb-0cd1-48af-8b8d-950849929573" />
<img width="1256" height="957" alt="Screenshot from 2025-07-28 16-47-19" src="https://github.com/user-attachments/assets/a1613bb2-f400-4362-924a-265868383edf" />
<img width="737" height="525" alt="Screenshot from 2025-07-28 16-29-06" src="https://github.com/user-attachments/assets/03fcef65-0581-4561-bd67-97d68ace7b74" />
<img width="1393" height="500" alt="Screenshot from 2025-07-28 16-29-41" src="https://github.com/user-attachments/assets/248bfb00-172f-428d-aeb7-f71b4777c02f" />
<img width="1257" height="561" alt="Screenshot from 2025-07-28 16-30-04" src="https://github.com/user-attachments/assets/608fadec-d134-4e69-9ac5-a655149fd415" />

